### PR TITLE
Fix texture array loader method

### DIFF
--- a/core/src/main/java/com/almagems/tokyorush/Terrain.java
+++ b/core/src/main/java/com/almagems/tokyorush/Terrain.java
@@ -25,7 +25,7 @@ public class Terrain {
                 "terrain_jungle.png", "terrain_jungle_dark.png", "terrain_water.png", "terrain_water_green.png"
         };
 
-        textures = TextureFactory.crreateArray(textureFileNames);
+        textures = TextureFactory.createArray(textureFileNames);
 //        textures = new Texture[size];
 //        textures[0] = TextureFactory.create("terrain_jungle.png");
 //        textures[1] = TextureFactory.create("terrain_jungle_dark.png");

--- a/core/src/main/java/com/almagems/tokyorush/TextureFactory.java
+++ b/core/src/main/java/com/almagems/tokyorush/TextureFactory.java
@@ -10,10 +10,10 @@ public class TextureFactory {
         return new Texture(folderName + "/" + fileName);
     }
 
-    public static Texture[] crreateArray(String[] fileNames) {
+    public static Texture[] createArray(String[] fileNames) {
         Texture[] textureArray = new Texture[fileNames.length];
 
-        for (int i = 0; i < fileNames.length - 1; ++i) {
+        for (int i = 0; i < fileNames.length; ++i) {
             textureArray[i] = create(fileNames[i]);
         }
 


### PR DESCRIPTION
## Summary
- fix typo in `TextureFactory` method name
- load every file when creating texture arrays
- update `Terrain` to call the corrected method

## Testing
- `./gradlew test --no-daemon` *(fails: Plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a166e8ef48321b636457a1d47f309